### PR TITLE
Feature puppet6 support

### DIFF
--- a/.fixtures.yaml
+++ b/.fixtures.yaml
@@ -3,6 +3,7 @@ fixtures:
     concat:           'git://github.com/puppetlabs/puppetlabs-concat'
     stdlib:           'git://github.com/puppetlabs/puppetlabs-stdlib'
     apt:              'git://github.com/puppetlabs/puppetlabs-apt'
-  
+    yumrepo_core:     'git://github.com/puppetlabs/puppetlabs-yumrepo_core'
+
   symlinks:
     ansible: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,3 @@ branches:
   only:
     - master
     - /^v\d/
-    - verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ matrix:
   - rvm: 2.4.1
     bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 5.1.0"
+  - rvm: 2.5.1
+    bundler_args: --without system_tests
+    env: PUPPET_GEM_VERSION="~> 6.1.0"
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,4 @@ branches:
   only:
     - master
     - /^v\d/
+    - verify

--- a/Gemfile
+++ b/Gemfile
@@ -37,11 +37,13 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')                  
+  gem 'beaker', '~>4.0'
+  gem 'beaker-puppet', '~>1.0'
+  # gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
   gem "beaker-pe",                                                               :require => false
-  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])                
+  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
 end
 

--- a/data/oses/distro/CentOS/8.yaml
+++ b/data/oses/distro/CentOS/8.yaml
@@ -1,0 +1,3 @@
+---
+ansible::repo::yum::epel_version: 8
+...

--- a/data/oses/distro/OracleLinux/8.yaml
+++ b/data/oses/distro/OracleLinux/8.yaml
@@ -1,0 +1,3 @@
+---
+ansible::repo::yum::epel_version: 8
+...

--- a/data/oses/distro/RedHat/8.yaml
+++ b/data/oses/distro/RedHat/8.yaml
@@ -1,0 +1,3 @@
+---
+ansible::repo::yum::epel_version: 8
+...

--- a/metadata.json
+++ b/metadata.json
@@ -8,25 +8,25 @@
   "project_page": "https://github.com/otherskins/puppet-ansible",
   "issues_url": "https://github.com/otherskins/puppet-ansible/issues",
   "tags": [
-    "ansible", 
-    "puppet", 
-    "ansible Inventory", 
-    "ansible.cfg", 
-    "puppet-agent", 
+    "ansible",
+    "puppet",
+    "ansible Inventory",
+    "ansible.cfg",
+    "puppet-agent",
     "hiera 5"
   ],
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.0.1 < 5.0.0"
+      "version_requirement": ">= 4.0.1 < 6.2.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 4.1.0 < 5.0.0"
+      "version_requirement": ">= 4.1.0 < 7.3.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.16.0 < 5.0.0"
+      "version_requirement": ">= 4.16.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -34,41 +34,50 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "26"
+        "26",
+        "27",
+        "28",
+        "29",
+        "30"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     }
   ]

--- a/spec/classes/ansible_spec.rb
+++ b/spec/classes/ansible_spec.rb
@@ -1,37 +1,34 @@
 require 'spec_helper'
 
 describe 'ansible' do
-  let(:facts) do
-    {
-      'operatingsystem' => 'CentOS',
-      'os' => {
-        'family' => 'RedHat',
-      },
-    }
-  end
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts)  { facts }
 
-  it { is_expected.to compile.with_all_deps }
+      it { is_expected.to compile.with_all_deps }
 
-  it { is_expected.to contain_class('ansible') }
-  it {
-    is_expected.to contain_class('ansible::install')
-      .that_comes_before('Class[ansible::config]')
-  }
-  it { is_expected.to contain_class('ansible::config') }
+      it { is_expected.to contain_class('ansible') }
+      it {
+        is_expected.to contain_class('ansible::install')
+          .that_comes_before('Class[ansible::config]')
+      }
+      it { is_expected.to contain_class('ansible::config') }
 
-  describe 'ansible::install' do
-    it { is_expected.to contain_package('ansible') }
-  end
+      describe 'ansible::install' do
+        it { is_expected.to contain_package('ansible') }
+      end
 
-  describe 'ansible::config' do
-    it { is_expected.to contain_file('/etc/ansible').with_ensure('directory') }
-    it { is_expected.to contain_file('/etc/ansible').with_mode('0755') }
+      describe 'ansible::config' do
+        it { is_expected.to contain_file('/etc/ansible').with_ensure('directory') }
+        it { is_expected.to contain_file('/etc/ansible').with_mode('0755') }
 
-    it { is_expected.to contain_file('/etc/ansible/ansible.cfg').with_ensure('file') }
-    it { is_expected.to contain_file('/etc/ansible/ansible.cfg').with_mode('0644') }
+        it { is_expected.to contain_file('/etc/ansible/ansible.cfg').with_ensure('file') }
+        it { is_expected.to contain_file('/etc/ansible/ansible.cfg').with_mode('0644') }
 
-    it { is_expected.to contain_concat('/etc/ansible/hosts').with_ensure('present') }
-    it { is_expected.to contain_concat('/etc/ansible/hosts').with_mode('0644') }
-    it { is_expected.to contain_concat('/etc/ansible/hosts').with_warn(true) }
+        it { is_expected.to contain_concat('/etc/ansible/hosts').with_ensure('present') }
+        it { is_expected.to contain_concat('/etc/ansible/hosts').with_mode('0644') }
+        it { is_expected.to contain_concat('/etc/ansible/hosts').with_warn(true) }
+      end
+    end
   end
 end

--- a/spec/defines/hosts_spec.rb
+++ b/spec/defines/hosts_spec.rb
@@ -1,11 +1,16 @@
 require 'spec_helper'
 
 describe 'ansible::hosts' do
-  let(:title) { 'webservers' }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:title) { 'webservers' }
+      let(:facts)  { facts }
+      let(:params) { { 'entrys' => ['192.168.0.1', '192.168.0.2'] } }
+      let(:pre_condition) { 'include ::ansible' }
 
-  let(:params) { { 'entrys' => ['192.168.0.1', '192.168.0.2'] } }
+      it { is_expected.to contain_concat__fragment('webservers') }
 
-  it { is_expected.to contain_concat__fragment('webservers') }
-
-  it { should compile }
+      it { should compile }
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
-require 'rspec-puppet'
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
 
 fixture_path = File.join(File.dirname(File.expand_path(__FILE__)), 'fixtures')
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,13 +1,16 @@
 require 'beaker-rspec'
-require 'beaker/puppet_install_helper'
+require 'beaker-puppet'
+require 'beaker-pe'
+#require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
 
 PROJECT_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
 UNSUPPORTED_PLATFORMS = ['windows', 'Darwin']
 
-run_puppet_install_helper
-install_ca_certs unless ENV['PUPPET_INSTALL_TYPE'] =~ %r{/pe/i}
+#run_puppet_install_helper
+install_puppet_on(hosts)
+# install_ca_certs unless ENV['PUPPET_INSTALL_TYPE'] =~ %r{/pe/i}
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
 


### PR DESCRIPTION
This module only affects the manifest.json file, where later/latest mainstream version support was added and changes to the spec testing, to actually test against all the specified versions, as well as support testing with the near latest version of puppet and the latest module dependencies.

All local spec tests are passing for me, and the travis ci is also passing.

It was a mission, but worth it for me. If and when this PR can be accepted and merged, I will be able to submit some additional improvements/support I have pending.
